### PR TITLE
Feature/docomo zatsudan

### DIFF
--- a/src/lib/docomo_zatsudan.ts
+++ b/src/lib/docomo_zatsudan.ts
@@ -1,37 +1,98 @@
 
 enum ToneType {
-  kansai = "20",
-  baby = "30",
+  kansai = "kansai",
+  akachan = "akachan",
 }
 
+enum Sex {
+  male = "男",
+  female = "女",
+}
+
+enum Mode {
+  dialog = "dialog",
+  srtr = "srtr",
+}
+
+// https://dev.smt.docomo.ne.jp/?p=docs.api.page&api_name=natural_dialogue&p_name=api_4#tag01
 interface IDialogueOption {
-  utt: string;
-  t?: ToneType;
-  context?: string;
+  nickname: string;
+  sex?: Sex;
+  age?: number;
+  place?: string;
+  mode: Mode;
+  t: ToneType;
 }
 
-const dialogueUrl = "https://api.apigw.smt.docomo.ne.jp/dialogue/v1/dialogue?APIKEY=" + process.env.DOCOMO_APIKEY;
+interface IDialogueRequest {
+  language: "ja-JP";
+  botId: "Chatting";
+  appId: string;
+  voiceText: string;
+  clientData: {
+    option: IDialogueOption;
+  };
+  appRecvTime: string;
+  appSendTime: string;
+}
+
+interface IDialogueResponse {
+  systemText: {
+    expression: string;
+    utterance: string;
+  };
+}
+
+const dialogueUrl =
+  "https://api.apigw.smt.docomo.ne.jp/naturalChatting/v1/dialogue?APIKEY="
+  + process.env.DOCOMO_APIKEY;
+
+const registUserUrl =
+  "https://api.apigw.smt.docomo.ne.jp/naturalChatting/v1/registration?APIKEY="
+  + process.env.DOCOMO_APIKEY;
 
 export const getDialogueMessage = (userId: string, message: string): string => {
-  const dialogueOptions: IDialogueOption = {
-    utt: message,
+  const dialogueOption: IDialogueOption = {
+    nickname: userId,
     t: ToneType.kansai,
+    mode: Mode.dialog,
   };
 
-  const contextId = "context" + userId;
-  const props = PropertiesService.getScriptProperties();
-  const context = props.getProperty(contextId);
-  if (context) {
-    dialogueOptions.context = context;
-  }
+  const appId = getUserAppId();
 
-  const options = {
+  const requestOption: IDialogueRequest = {
+    language: "ja-JP",
+    botId: "Chatting",
+    appId,
+    voiceText: message,
+    clientData: {
+      option: dialogueOption,
+    },
+    appRecvTime: Utilities.formatDate(new Date(), "Asia/Tokyo", "yyyyMMdd HH:mm:ss"),
+    appSendTime: Utilities.formatDate(new Date(), "Asia/Tokyo", "yyyyMMdd HH:mm:ss"),
+  };
+
+  const option = {
     method: "post",
     contentType: "text/json",
-    payload: JSON.stringify(dialogueOptions),
+    payload: JSON.stringify(requestOption),
   };
-  const res = UrlFetchApp.fetch(dialogueUrl, options as any);
-  const content = JSON.parse(res.getContentText());
-  props.setProperty(contextId, content.context);
-  return content.utt;
+  const res = UrlFetchApp.fetch(dialogueUrl, option as any);
+  const json: IDialogueResponse = JSON.parse(res.getContentText());
+  return json.systemText.utterance;
+};
+
+const getUserAppId = (): string => {
+  const option = {
+    method: "post",
+    contentType: "application/json",
+    payload: JSON.stringify({
+      botId: "Chatting",
+      appKind: "slack",
+    }),
+  };
+  const res = UrlFetchApp.fetch(registUserUrl, option as any);
+  const json: { appId: string } = JSON.parse(res.getContentText());
+
+  return json.appId;
 };

--- a/src/lib/docomo_zatsudan.ts
+++ b/src/lib/docomo_zatsudan.ts
@@ -18,7 +18,7 @@ enum Mode {
 interface IDialogueOption {
   nickname: string;
   sex?: Sex;
-  age?: number;
+  age?: string;
   place?: string;
   mode: Mode;
   t: ToneType;
@@ -54,11 +54,14 @@ const registUserUrl =
 export const getDialogueMessage = (userId: string, message: string): string => {
   const dialogueOption: IDialogueOption = {
     nickname: userId,
+    sex: Sex.female,
+    age: "17",
+    place: "東京",
     t: ToneType.kansai,
     mode: Mode.dialog,
   };
 
-  const appId = getUserAppId();
+  const appId = getUserAppId(userId);
 
   const requestOption: IDialogueRequest = {
     language: "ja-JP",
@@ -74,7 +77,7 @@ export const getDialogueMessage = (userId: string, message: string): string => {
 
   const option = {
     method: "post",
-    contentType: "text/json",
+    contentType: "application/json",
     payload: JSON.stringify(requestOption),
   };
   const res = UrlFetchApp.fetch(dialogueUrl, option as any);
@@ -82,7 +85,13 @@ export const getDialogueMessage = (userId: string, message: string): string => {
   return json.systemText.utterance;
 };
 
-const getUserAppId = (): string => {
+const getUserAppId = (userId: string): string => {
+  const props = PropertiesService.getScriptProperties();
+  const key = `docomo-userAppId-${userId}`;
+  const userAppId = props.getProperty(key);
+
+  if (userAppId) { return userAppId; }
+
   const option = {
     method: "post",
     contentType: "application/json",
@@ -93,6 +102,8 @@ const getUserAppId = (): string => {
   };
   const res = UrlFetchApp.fetch(registUserUrl, option as any);
   const json: { appId: string } = JSON.parse(res.getContentText());
+
+  props.setProperty(key, json.appId);
 
   return json.appId;
 };


### PR DESCRIPTION
これの対応

https://dev.smt.docomo.ne.jp/?p=docs.api.page&api_name=dialogue&p_name=api_reference

```
自然対話APIのリリースにあたり、既存の対話系APIは2018年6月末に廃止を予定しております。
以下の対話系APIにつきましては自然対話APIで同等の機能をご提供しておりますので、サポート終了までに移行をご検討いただきますようお願い申し上げます。
（多くのご要望をいただいたため、5/28より自然対話APIの商用利用が可能になりました。） 
・「雑談対話」→「自然対話：雑談対話」
・「発話理解」→「自然対話：意図解釈」
・「知識Q&A」→「自然対話：知識検索」
・「シナリオ対話」→「自然対話：FAQチャット」
お手数をおかけしますが、ご検討をお願いいたします。
```